### PR TITLE
Js/edits for node scaling and font soze increase

### DIFF
--- a/inst/htmlwidgets/collapsibleTree.js
+++ b/inst/htmlwidgets/collapsibleTree.js
@@ -66,7 +66,9 @@ HTMLWidgets.widget({
       .attr('transform', function(d) {
         return 'translate(' + source.y0 + ',' + source.x0 + ')';
       })
-      .on('click', click);
+      .on('click', click)
+      .on('mouseover', mouseover)
+      .on('mouseout', mouseout);
 
       // Add tooltips, if specified in options
       if (options.tooltip) {
@@ -168,11 +170,13 @@ HTMLWidgets.widget({
       // On exit reduce the node circles size to 0
       nodeExit.select('circle')
       .attr('r', 1e-6)
-      .attr('class', 'hidden');
+      .attr('class', 'hidden')
+      .remove();
 
       // On exit reduce the opacity of text labels
       nodeExit.select('text')
-      .style('fill-opacity', 1e-6);
+      .style('fill-opacity', 1e-6)
+      .remove();
 
   // ****************** links section ***************************
 
@@ -269,6 +273,59 @@ HTMLWidgets.widget({
 
         update(d);
 
+        var nodes = d3.selectAll("circle.node").size()
+
+        //console.log(d._isSelected);
+        if(d._isSelected == false) {
+          nodes = (nodes - d._children.length)
+          //console.log(d._children.length);
+        }
+        console.log(nodes);
+
+        if(nodes < 35) {
+            // width and height, corrected for margins
+            var heightMargin = height - options.margin.top - options.margin.bottom,
+            widthMargin = width - options.margin.left - options.margin.right;
+
+            // Update the treemap to fit the new canvas size
+            treemap = d3.tree().size([heightMargin, widthMargin])
+            .separation(separationFun);
+            update(root)
+        }
+
+        if(nodes >= 35 && nodes < 130) {
+            // width and height, corrected for margins
+            var heightMargin = height - options.margin.top - options.margin.bottom,
+            widthMargin = width - options.margin.left - options.margin.right;
+
+            // Update the treemap to fit the new canvas size
+            treemap = d3.tree().size([heightMargin*2, widthMargin])
+            .separation(separationFun);
+            update(root)
+        }
+
+        if(nodes >= 130 && nodes < 160) {
+            // width and height, corrected for margins
+            var heightMargin = height - options.margin.top - options.margin.bottom,
+            widthMargin = width - options.margin.left - options.margin.right;
+
+            // Update the treemap to fit the new canvas size
+            treemap = d3.tree().size([heightMargin*3, widthMargin])
+            .separation(separationFun);
+            update(root)
+        }
+
+        if(nodes > 160) {
+            // width and height, corrected for margins
+            var heightMargin = height - options.margin.top - options.margin.bottom,
+            widthMargin = width - options.margin.left - options.margin.right;
+
+            // Update the treemap to fit the new canvas size
+            treemap = d3.tree().size([heightMargin*4, widthMargin])
+            .separation(separationFun);
+            update(root)
+        }
+
         // Hide the tooltip after clicking
         tooltip.transition()
         .duration(100)
@@ -304,26 +361,44 @@ HTMLWidgets.widget({
 
       // Show tooltip on mouseover
       function mouseover(d) {
-        tooltip.transition()
-        .duration(200)
-        .style('opacity', .9);
 
-        // Show either a constructed tooltip, or override with one from the data
-        tooltip.html(
-          d.data.tooltip || d.data.name + '<br>' +
-          options.attribute + ': ' + d.data.WeightOfNode
-        )
+        //d3.select(this)
+        //  .style('font-size', function(d) {
+        //    return (options.fontSize + 1) + 'px';
+        //  })
+        //  .style('font-weight', function(d) {
+        //    return 'bolder';
+        //  });
+
+        //tooltip.transition()
+        //.duration(200)
+        //.style('opacity', .9);
+
+        //// Show either a constructed tooltip, or override with one from the data
+        //tooltip.html(
+        //  d.data.tooltip || d.data.name + '<br>' +
+        //  options.attribute + ': ' + d.data.WeightOfNode
+        //)
         // Make the tooltip font size just a little bit bigger
-        .style('font-size', (options.fontSize + 1) + 'px')
-        .style('left', (d3.event.layerX) + 'px')
-        .style('top', (d3.event.layerY - 10) + 'px');
+        //.style('font-size', (options.fontSize + 1) + 'px')
+        //.style('left', (d3.event.layerX) + 'px')
+        //.style('top', (d3.event.layerY - 10) + 'px');
       }
 
       // Hide tooltip on mouseout
       function mouseout(d) {
-        tooltip.transition()
-        .duration(500)
-        .style('opacity', 0);
+
+        //d3.select(this)
+        //  .style('font-size', function(d) {
+        //    return (options.fontSize) + 'px';
+        //  })
+        //  .style('font-weight', function(d) {
+        //    return 'lighter';
+        //  });
+
+        //tooltip.transition()
+        //.duration(500)
+        //.style('opacity', 0);
       }
     }
 
@@ -412,10 +487,13 @@ HTMLWidgets.widget({
 function separationFun(a, b) {
   var height = Math.sqrt(a.data.SizeOfNode) + Math.sqrt(b.data.SizeOfNode),
   // Scale distance to SizeOfNode, if defined
-  distance = (height) / 25; // increase denominator for better spacing in DEAP app
-  //if (distance < .4) {
-  //  distance = .4
-  //}
+  distance = (height)/25; // increase denominator for better spacing in DEAP app
+  if (distance < .4) {
+    distance = .4
+  }
+  if (distance > 1.5) {
+    distance = 1.5
+  }
   //console.log(distance);
   return (a.parent === b.parent ? distance : 1);
 };

--- a/inst/htmlwidgets/collapsibleTree.js
+++ b/inst/htmlwidgets/collapsibleTree.js
@@ -66,9 +66,7 @@ HTMLWidgets.widget({
       .attr('transform', function(d) {
         return 'translate(' + source.y0 + ',' + source.x0 + ')';
       })
-      .on('click', click)
-      .on('mouseover', mouseover)
-      .on('mouseout', mouseout);
+      .on('click', click);
 
       // Add tooltips, if specified in options
       if (options.tooltip) {
@@ -357,15 +355,15 @@ HTMLWidgets.widget({
       }
 
       // Show tooltip on mouseover
-      function mouseover(d) {
+      function mouseover(d, i) {
 
-        //d3.select(this)
-        //  .style('font-size', function(d) {
-        //    return (options.fontSize + 1) + 'px';
-        //  })
-        //  .style('font-weight', function(d) {
-        //    return 'bolder';
-        //  });
+        if(d._isSelected == false || d._isSelected == null){
+              console.log(this);
+              d3.select(this).select('text.node-text')
+                .style('font-size', '14px')
+                .style('font-weight', 'bolder');
+            }
+
 
         tooltip.transition()
         .duration(200)
@@ -383,15 +381,13 @@ HTMLWidgets.widget({
       }
 
       // Hide tooltip on mouseout
-      function mouseout(d) {
+      function mouseout(d, i) {
 
-        //d3.select(this)
-        //  .style('font-size', function(d) {
-        //    return (options.fontSize) + 'px';
-        //  })
-        //  .style('font-weight', function(d) {
-        //    return 'lighter';
-        //  });
+         if(d._isSelected == false || d._isSelected == null){
+              d3.select(this).select('text.node-text')
+                .style('font-size', '13px')
+                .style('font-weight', 'lighter');
+            }
 
         tooltip.transition()
         .duration(500)

--- a/inst/htmlwidgets/collapsibleTree.js
+++ b/inst/htmlwidgets/collapsibleTree.js
@@ -169,14 +169,11 @@ HTMLWidgets.widget({
 
       // On exit reduce the node circles size to 0
       nodeExit.select('circle')
-      .attr('r', 1e-6)
-      .attr('class', 'hidden')
-      .remove();
+      .attr('r', 1e-6);
 
       // On exit reduce the opacity of text labels
       nodeExit.select('text')
-      .style('fill-opacity', 1e-6)
-      .remove();
+      .style('fill-opacity', 1e-6);
 
   // ****************** links section ***************************
 
@@ -370,19 +367,19 @@ HTMLWidgets.widget({
         //    return 'bolder';
         //  });
 
-        //tooltip.transition()
-        //.duration(200)
-        //.style('opacity', .9);
+        tooltip.transition()
+        .duration(200)
+        .style('opacity', .9);
 
-        //// Show either a constructed tooltip, or override with one from the data
-        //tooltip.html(
-        //  d.data.tooltip || d.data.name + '<br>' +
-        //  options.attribute + ': ' + d.data.WeightOfNode
-        //)
+        // Show either a constructed tooltip, or override with one from the data
+        tooltip.html(
+          d.data.tooltip || d.data.name + '<br>' +
+          options.attribute + ': ' + d.data.WeightOfNode
+        )
         // Make the tooltip font size just a little bit bigger
-        //.style('font-size', (options.fontSize + 1) + 'px')
-        //.style('left', (d3.event.layerX) + 'px')
-        //.style('top', (d3.event.layerY - 10) + 'px');
+        .style('font-size', (options.fontSize + 1) + 'px')
+        .style('left', (d3.event.layerX) + 'px')
+        .style('top', (d3.event.layerY - 10) + 'px');
       }
 
       // Hide tooltip on mouseout
@@ -396,9 +393,9 @@ HTMLWidgets.widget({
         //    return 'lighter';
         //  });
 
-        //tooltip.transition()
-        //.duration(500)
-        //.style('opacity', 0);
+        tooltip.transition()
+        .duration(500)
+        .style('opacity', 0);
       }
     }
 

--- a/inst/htmlwidgets/collapsibleTree.js
+++ b/inst/htmlwidgets/collapsibleTree.js
@@ -360,7 +360,7 @@ HTMLWidgets.widget({
         if(d._isSelected == false || d._isSelected == null){
               console.log(this);
               d3.select(this).select('text.node-text')
-                .style('font-size', '14px')
+                .style('font-size', '12px')
                 .style('font-weight', 'bolder');
             }
 
@@ -385,7 +385,7 @@ HTMLWidgets.widget({
 
          if(d._isSelected == false || d._isSelected == null){
               d3.select(this).select('text.node-text')
-                .style('font-size', '13px')
+                .style('font-size', '11px')
                 .style('font-weight', 'lighter');
             }
 


### PR DESCRIPTION
Hi Patrick, updates for dynamic height scaling of tree by number of nodes displayed are included in the PR. Important code block is on lines 273 - 324. You'll see several thresholds defined there that describe how the tree height adjusts to number of nodes displayed. You can adjust those thresholds as needed, or even add more if the final tree is much larger and more complex than the current data table is showing.